### PR TITLE
add support for path_effects to overlay_ax

### DIFF
--- a/colorstamps/helpers.py
+++ b/colorstamps/helpers.py
@@ -279,7 +279,7 @@ class Stamp:
         self.vmax_0 = 1
         self.vmax_1 = 1
 
-    def overlay_ax(self, ax, lower_left_corner = [0.66, 0.66], width = None, height = 0.25):
+    def overlay_ax(self, ax, lower_left_corner = [0.66, 0.66], width = None, height = 0.25, path_effects=None):
         '''
         overlays new axes over the existing axes ('ax') with the colormap
 
@@ -313,6 +313,20 @@ class Stamp:
         cmap_ax = fig.add_axes(new_pos)
         extent = (self.vmin_1, self.vmax_1, self.vmin_0, self.vmax_0)
         cmap_ax.imshow(self.cmap, origin = 'lower', extent = extent, aspect='auto')
+
+        if path_effects:
+            for tick in cmap_ax.xaxis.get_major_ticks():
+                tick.label1.set_path_effects(path_effects)
+            for tick in cmap_ax.yaxis.get_major_ticks():
+                tick.label1.set_path_effects(path_effects)
+            for minor_tick in cmap_ax.xaxis.get_minor_ticks():
+                minor_tick.label1.set_path_effects(path_effects)
+            for minor_tick in cmap_ax.yaxis.get_minor_ticks():
+                minor_tick.label1.set_path_effects(path_effects)
+            cmap_ax.title.set_path_effects(path_effects)
+            cmap_ax.xaxis.label.set_path_effects(path_effects)
+            cmap_ax.yaxis.label.set_path_effects(path_effects)
+
         return cmap_ax
 
     def show_in_ax(self, cmap_ax):


### PR DESCRIPTION
When embedding the 2D colormap into the plot itself in full or just a part of it, it can happen that the labels and or ticks of the colormap are not visible due to being very similar in color to the picture itself. I fix this by allowing the user to pass `path_effects` to add an outline to the labels and ticks.

Here is an example of a problematic plot with $\phi$ not visible on the top and the fixed version below. 
![output](https://github.com/user-attachments/assets/cdc89ff7-f324-4df3-8ef9-ba8615ec1ba4)



You can reproduce the figure above with my fork of the repo with this code snippet. 

Happy to modify the functionality in any way :)
Looking forward to hearing your opinion @trygvrad !
```python
import matplotlib.pyplot as plt
import colorstamps
import matplotlib.patheffects as PathEffects

img = colorstamps.helpers.get_random_data()
rgb, stamp = colorstamps.apply_stamp(
    img[:, :, 0],
    img[:, :, 1],
    "funnel",
    vmin_0=-1.2,
    vmax_0=1.2,
    vmin_1=-1,
    vmax_1=1,
)


fig, axes = plt.subplots(2)

# plot the original image
ax = axes[0]
ax.imshow(rgb)

# show colormap as overlay
overlaid_ax = stamp.overlay_ax(
    ax, lower_left_corner=[0.7, 0.85], width=0.2, path_effects=None
)
overlaid_ax.set_ylabel(r"$\phi$")
overlaid_ax.set_xlabel(r"$\omega$")


# plot the fix
ax = axes[1]
ax.imshow(rgb)

# add path effects to make text more readable
path_effects = [PathEffects.withStroke(linewidth=3, foreground="w")]

# show colormap as overlay
overlaid_ax = stamp.overlay_ax(
    ax, lower_left_corner=[0.7, 0.85], width=0.2, path_effects=path_effects
)
overlaid_ax.set_ylabel(r"$\phi$")
overlaid_ax.set_xlabel(r"$\omega$")

```